### PR TITLE
Added row major publication of occupancy grid for visualization in rviz

### DIFF
--- a/include/avt_341/perception/elevation_grid.h
+++ b/include/avt_341/perception/elevation_grid.h
@@ -69,7 +69,7 @@ class ElevationGrid{
         dilate_ = use_dil;
     }
 
-    avt_341::msg::OccupancyGrid GetGrid(std::string grid_type);
+    avt_341::msg::OccupancyGrid GetGrid(std::string grid_type, bool row_major=false);
 
     void SetCorner(float llx, float lly){
         llx_ = llx;
@@ -77,6 +77,7 @@ class ElevationGrid{
     }
 
   private:
+    void GetGridCell(const std::string & grid_type, avt_341::msg::OccupancyGrid & grid, const int & i, const int & j, int & c);
     void ResizeGrid();
     void FillImage();
     std::vector< std::vector<Cell> > cells_;

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -37,6 +37,7 @@
     <param name="overhead_clearance" value="7.0" />
     <param name="warmup_time" value="5.0" />
     <param name="use_registered" value="true" />
+    <param name="display" value="$(arg display)" />
   </node>
 
   <node name="vehicle_control_node" pkg="avt_341" type="avt_341_control_node" required="true" output="screen" >

--- a/launch/mavs_example.launch
+++ b/launch/mavs_example.launch
@@ -37,6 +37,7 @@
     <param name="overhead_clearance" value="7.0" />
     <param name="warmup_time" value="5.0" />
     <param name="use_registered" value="true" />
+    <param name="display" value="$(arg display)" />
   </node>
 
   <node name="vehicle_control_node" pkg="avt_341" type="avt_341_control_node" required="true" output="screen" >

--- a/rviz/avt_341.rviz
+++ b/rviz/avt_341.rviz
@@ -5,7 +5,9 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Global Options1
+        - /OccupancyGrid1
         - /CandidatePaths1/Namespaces1
+        - /SelectedLocalPath1
       Splitter Ratio: 0.5
     Tree Height: 751
   - Class: rviz/Selection
@@ -104,7 +106,7 @@ Visualization Manager:
       Draw Behind: true
       Enabled: true
       Name: OccupancyGrid
-      Topic: /avt_341/occupancy_grid
+      Topic: /avt_341/occupancy_grid_vis
       Unreliable: false
       Use Timestamp: false
       Value: true
@@ -121,7 +123,7 @@ Visualization Manager:
       Marker Topic: /avt_341/candidate_paths_blocked
       Name: BlockedCandidatePaths
       Namespaces:
-        {}
+        "": true
       Queue Size: 100
       Value: true
     - Alpha: 1
@@ -138,7 +140,7 @@ Visualization Manager:
       Offset:
         X: 0
         Y: 0
-        Z: 0
+        Z: 0.10000000149011612
       Pose Color: 255; 85; 255
       Pose Style: None
       Radius: 0.029999999329447746
@@ -162,14 +164,14 @@ Visualization Manager:
       Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: 0
+      Max Intensity: 7
       Min Color: 0; 0; 0
       Min Intensity: 0
       Name: Lidar
       Position Transformer: XYZ
       Queue Size: 10
       Selectable: true
-      Size (Pixels): 10
+      Size (Pixels): 6
       Size (m): 1
       Style: Points
       Topic: /avt_341/points
@@ -230,26 +232,21 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: rviz/Orbit
-      Distance: 142.86398315429688
+      Angle: 0
+      Class: rviz/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
-      Focal Point:
-        X: 21.56048583984375
-        Y: 0.4441010057926178
-        Z: 1.82915198802948
-      Focal Shape Fixed Size: true
-      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 1.2547966241836548
+      Scale: 15.06517219543457
       Target Frame: <Fixed Frame>
-      Value: Orbit (rviz)
-      Yaw: 4.763188362121582
+      Value: TopDownOrtho (rviz)
+      X: 6.361544132232666
+      Y: -2.887704849243164
     Saved: ~
 Window Geometry:
   Displays:

--- a/src/simulation/avt_341_sim_test_node.cpp
+++ b/src/simulation/avt_341_sim_test_node.cpp
@@ -51,7 +51,10 @@ int main(int argc, char **argv){
 	// create and populate the point cloud message that will be published
   avt_341::msg::PointCloud2 pc2;
 	std::vector<avt_341::utils::vec3> points {
-	  avt_341::utils::vec3(50.0, 0.0, 0.0)
+	  avt_341::utils::vec3(50.0, 0.0, 0.0),
+    avt_341::utils::vec3(15.1, 7.8, 5.0),
+    avt_341::utils::vec3(14.5, 8.5, 7.0),
+    avt_341::utils::vec3(14.6, 8.2, 4.5)
 	};
   avt_341::perception::PointCloudGenerator::toROSMsg(points, pc2);
   pc2.header.frame_id = "odom";


### PR DESCRIPTION
There was a bug with rviz visualization where the occupancy grid would not display properly in rviz because its currently column major (outer loop through x or columns) instead of row major (outer loop through y or rows) which rviz expects to display.
To prevent unintentionally changing the algorithm code behaviour, instead of changing all instances of the occupancy grid to be row major I just added a new publisher which publishes the occupancy grid in row major format only when rviz visualisation is enabled.

The default sim test example node also didn't have any non-zero occupancy grid values so I added a few for testing.

__Before change:__ The occupancy grid displayed by rviz doesn't match with the point cloud because rviz expects row-major format. This is just a display issue, the algorithm code works as intended.

![image](https://user-images.githubusercontent.com/9484797/130363891-b937794c-4eb4-4c58-af9a-d91f265acc69.png)

__After change:__

![image](https://user-images.githubusercontent.com/9484797/130306107-df02a269-e005-4120-8ee5-977bd33f9b08.png)
