### PR TITLE
Throttle waypoints fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,22 @@ if($ENV{ROS_DISTRO} STREQUAL "noetic")
     rospy
     pcl_ros
     std_msgs
+    geometry_msgs
+    navs_msgs
     tf
+    tf2
+    tf2_ros
   )
 else()
   find_package(catkin REQUIRED COMPONENTS
     roscpp
     rospy
     std_msgs
-    tf  
+    geometry_msgs
+    navs_msgs
+    tf
+    tf2
+    tf2_ros
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if($ENV{ROS_DISTRO} STREQUAL "noetic")
     pcl_ros
     std_msgs
     geometry_msgs
-    navs_msgs
+    nav_msgs
     tf
     tf2
     tf2_ros
@@ -28,7 +28,7 @@ else()
     rospy
     std_msgs
     geometry_msgs
-    navs_msgs
+    nav_msgs
     tf
     tf2
     tf2_ros

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,7 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <depend>tf2_ros</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/src/planning/global/gps_to_enu_node.cpp
+++ b/src/planning/global/gps_to_enu_node.cpp
@@ -16,6 +16,8 @@
 #include "nav_msgs/Path.h"
 #include "nav_msgs/Odometry.h"
 #include "sensor_msgs/NavSatFix.h"
+#include "geometry_msgs/PoseStamped.h"
+#include "tf2_ros/transform_listener.h"
 //#include "avt_341/node/ros_types.h"
 //#include "avt_341/node/node_proxy.h"
 // local includes

--- a/src/planning/global/gps_to_enu_node.cpp
+++ b/src/planning/global/gps_to_enu_node.cpp
@@ -19,6 +19,7 @@
 #include "geometry_msgs/PoseStamped.h"
 #include "geometry_msgs/TransformStamped.h"
 #include "tf2_ros/transform_listener.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 //#include "avt_341/node/ros_types.h"
 //#include "avt_341/node/node_proxy.h"
 // local includes
@@ -132,13 +133,13 @@ int main(int argc, char **argv){
                     // pack into ROS Pose msg
                     geometry_msgs::PoseStamped utm_pose, odom_pose;
                     // metadata so TF can transform correctly
-                    utm_pose.header.frame = "utm";
+                    utm_pose.header.frame_id = "utm";
                     utm_pose.header.stamp = ros::Time::now();
                     utm_pose.pose.position.x = utm_wp[0]; // UTM
                     utm_pose.pose.position.y = utm_wp[1]; // UTM
                     utm_pose.pose.position.z = 0; // assume 2D waypoints for now
                     // apply transform
-                    tfBuffer.transform(utm_pose, &odom_pose, "odom", ros::Duration(600)) // 10 minute timeout to apply the transform
+                    tfBuffer.transform(utm_pose, &odom_pose, "odom", ros::Duration(600)); // 10 minute timeout to apply the transform
                     // this is a repulsive hack, but it minimizes code changes for now
                     utm_wp[0] = utm_pose.pose.position.x;
                     utm_wp[1] = utm_pose.pose.position.y;

--- a/src/planning/global/gps_to_enu_node.cpp
+++ b/src/planning/global/gps_to_enu_node.cpp
@@ -17,6 +17,7 @@
 #include "nav_msgs/Odometry.h"
 #include "sensor_msgs/NavSatFix.h"
 #include "geometry_msgs/PoseStamped.h"
+#include "geometry_msgs/TransformStamped.h"
 #include "tf2_ros/transform_listener.h"
 //#include "avt_341/node/ros_types.h"
 //#include "avt_341/node/node_proxy.h"


### PR DESCRIPTION
This PR changes the gps_to_enu node to use the ROS TF tree when transforming waypoints from UTM coordinates to local coordinates in the odom frame. The node will wait and periodically poll until a valid transform is available.